### PR TITLE
Problem: Unable to View SSH Key in Windows command prompt due to 'cat' Command Error.

### DIFF
--- a/docs/content-onboarding/onboarding.md
+++ b/docs/content-onboarding/onboarding.md
@@ -136,9 +136,13 @@ Host github.com
 * Enter `Title` of your choice (e.g. `ssh-key-TUC`).
 * Set `Key Type` as `Authentication Key`.
 * Paste your public key from the file that was generated (`C:\Users\...\.ssh\id_ed25519.pub`) into the `Key` field.
-* Incase you are not sure what the key is, open a command prompt and type
+* Incase you are unsure of what the key is, open a command prompt and type
 ```
 cat ~/.ssh/id_ed25519.pub
+```
+* If that doesn't work, open Windows PowerShell and type
+```
+Get-Content ~\.ssh\id_ed25519.pub
 ```
 * You will see ssh-ed25519 ... .. . ssh-key-TUC, make sure to copy paste the entire thing to the key field.
 * Click on `Add SSH Key` button.

--- a/docs/content-onboarding/onboarding.md
+++ b/docs/content-onboarding/onboarding.md
@@ -37,7 +37,7 @@ Setup Bitlocker on Windows 10:
 
 ## Install the following tools
 
-This also applies if your use your own computer.
+This also applies if you use your own computer.
 
 ### Windows
 

--- a/docs/content-onboarding/working-with-GitHub.md
+++ b/docs/content-onboarding/working-with-GitHub.md
@@ -18,7 +18,7 @@ Most of our colleagues use [SourceTree](https://www.sourcetreeapp.com/) as versi
 
 Sourcetree is a sofware solution still recommended for windows to provide a git graphical interface. It allows to connect to git repositories to easily perform all necessary git related tasks. it is a simple and user friendly which makes life of git users easier.  
 
-You are free to use other tools like [command line](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line) or [TortoiseGit](https://tortoisegit.org/) but we can not provide support for these tools.
+You are free to use other tools like [command line](https://git-scm.com/book/en/v2/Getting-Started-The-Command-Line) or [TortoiseGit](https://tortoisegit.org/) but we cannot provide support for these tools.
 
 
 ### Linux
@@ -38,7 +38,7 @@ We use "forking workflow." Please read
 
 - This new fork will be your personal fork of the upstream project. This new fork will be called your "origin".
 
-- Clone your personal fork (origin) to your harddrive using Git/Sourcetree. The SSH Path to your origin can be found in the web interface (as shown in the following screenshot). This will be your working directory. Please commit and push regularily!
+- Clone your personal fork (origin) to your harddrive using Git/Sourcetree. The SSH Path to your origin can be found in the web interface (as shown in the following screenshot). This will be your working directory. Please commit and push regularly!
 
 !!! info
     If you are using <b>git-bash</b>, use insert button to paste the SSH path after copying it to clipboard.


### PR DESCRIPTION
Solution: Updated the documentation to include the correct Windows PowerShell command for viewing the SSH key. 

The previous command (cat ~/.ssh/id_rsa.pub) caused an error in Windows command prompt since 'cat' is not a recognized command. 

Added the PowerShell equivalent (Get-Content ~\.ssh\id_ed25519.pub) to ensure compatibility across different operating systems.