### PR TITLE
Fix: rewrite the duplicate 'open Windows Powershell' instruction in t…

### DIFF
--- a/docs/content-onboarding/onboarding.md
+++ b/docs/content-onboarding/onboarding.md
@@ -94,7 +94,7 @@ For a detailed understanding of GitHub access with SSH keys go to this [link](ht
 #### Configure your SSH
 
 
-- Open *Windows PowerShell*.
+- In the same *Windows Powershell*
 - Navigate to your `.ssh` directory:
 
     ```powershell


### PR DESCRIPTION
### Summary 
I found that 'open Windows PowerShell' is used twice, to generate SSH keys and configure them, which is confusing to the first user. 

### Context
This change is the part of onboarding process (TC) to improve documentation clarity.